### PR TITLE
R14B01 nad R14B are temporarily not provided on travis-ci.org.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ otp_release:
    - R14B04
    - R14B03
    - R14B02
-   - R14B01
-   - R14B
    - R14A
    - R13B04
    - R13B03


### PR DESCRIPTION
We could not make them build on Ubuntu 11.04.
