### PR TITLE
Variable List can be bound to another list.

### DIFF
--- a/src/mustache.erl
+++ b/src/mustache.erl
@@ -90,7 +90,7 @@ pre_compile(T, State) ->
   {ok, CompiledTagRE} = re:compile(TagRE, [dotall]),
   State2 = State#mstate{section_re = CompiledSectionRE, tag_re = CompiledTagRE},
   "fun(Ctx) -> " ++
-    "CFun = fun(A, B) -> A end, " ++
+    "CFun = fun(_Key, A, B) -> A end, " ++
     compiler(T, State2) ++ " end.".
 
 compiler(T, State) ->


### PR DESCRIPTION
The function mustache:compiler/2 generate a complex structure of fun out of the template. When you have a template like this one:
{{#apis}}
 {{url}}
    {{#method}}
      {{stuff}}
    {{/method}}
{{/apis}}

... and apis and methods are different lists, the method will generete a error message. This is a small demonstration of the problem:

(fun() -> List = a, (fun() -> List = b, List end)() end)(). 

This pull request might not be the best solution, but I hope it works.
