### PR TITLE
Proper escaping in regexes

### DIFF
--- a/src/mustache.erl
+++ b/src/mustache.erl
@@ -81,7 +81,7 @@ render(Mod, CompiledTemplate, CtxData) ->
   lists:flatten(CompiledTemplate(Ctx1)).
 
 pre_compile(T, State) ->
-  SectionRE = "{{(#|\\^)([^}]*)}}\s*(.+?){{/\\2}}\s*",
+  SectionRE = "{{(#|\\^)([^}]*)}}\\s*(.+?){{/\\2}}\\s*",
   {ok, CompiledSectionRE} = re:compile(SectionRE, [dotall]),
   TagRE = "{{(#|=|!|<|>|{|&)?(.+?)\\1?}}+",
   {ok, CompiledTagRE} = re:compile(TagRE, [dotall]),


### PR DESCRIPTION
In Erlang "\}" doesn't make sense in a string so I removed all those.

Second commit fixes a missing \ to properly escape the '.'.

The third commit I'm not 100% sure about, but it seems likely that you want to match on _all_ whitespace.  \s means literal space in a string and will be treated as such in the regex. \s means \s to the regex which will match [\s\t\r\n](i.e. space, tab, cr, lf).
