### PR TITLE
Escape special characters in pre-compiled code generation

### DIFF
--- a/src/mustache.erl
+++ b/src/mustache.erl
@@ -129,11 +129,11 @@ compile_tags(T, State) ->
       Content = string:substr(T, C0 + 1, C1),
       Kind = tag_kind(T, K),
       Result = compile_tag(Kind, Content, State),
-      "[\"" ++ Front ++
+      "[\"" ++ escape_special(Front) ++
         "\" | [" ++ Result ++
         " | " ++ compile_tags(Back, State) ++ "]]";
     nomatch ->
-      "[\"" ++ T ++ "\"]"
+      "[\"" ++ escape_special(T) ++ "\"]"
   end.
 
 tag_kind(_T, {-1, 0}) ->
@@ -220,6 +220,19 @@ escape(["&" | Rest], Acc) ->
   escape(Rest, lists:reverse("&amp;", Acc));
 escape([X | Rest], Acc) ->
   escape(Rest, [X | Acc]).
+
+escape_special(String) ->
+    lists:flatten([escape_char(Char) || Char <- String]).
+
+escape_char($\0) -> "\\0";
+escape_char($\n) -> "\\n";
+escape_char($\t) -> "\\t";
+escape_char($\b) -> "\\b";
+escape_char($\r) -> "\\r";
+escape_char($')  -> "\\'";
+escape_char($")  -> "\\\"";
+escape_char($\\) -> "\\\\";
+escape_char(Char) -> Char.
 
 %%---------------------------------------------------------------------------
 

--- a/test/mustache_tests.erl
+++ b/test/mustache_tests.erl
@@ -38,3 +38,8 @@ integer_values_too_test() ->
     Ctx = dict:from_list([{name, "Chris"}, {value, 10000}]),
     Result = mustache:render("Hello {{name}}~nYou have just won ${{value}}!", Ctx),
     ?assertEqual("Hello Chris~nYou have just won $10000!", Result).
+
+specials_test() ->
+    Ctx = dict:from_list([{name, "Chris"}, {value, 10000}]),
+    Result = mustache:render("\'Hello\n\"{{name}}\"~nYou \"have\" ju\0st\\ won\b\r\"${{value}}!\"\t", Ctx),
+    ?assertEqual("\'Hello\n\"Chris\"~nYou \"have\" ju\0st\\ won\b\r\"$10000!\"\t", Result).


### PR DESCRIPTION
Lack of pre-compiled code escaping during its preparation caused erlang scanner to crash if some special characters were included in the template. 
