### PR TITLE
More functionality

### DIFF
--- a/src/mustache.erl
+++ b/src/mustache.erl
@@ -29,7 +29,8 @@
 
 -record(mstate, {mod = undefined,
                  section_re = undefined,
-                 tag_re = undefined}).
+                 tag_re = undefined,
+                 path = []}).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -92,11 +93,8 @@ render(Mod, CompiledTemplate, CtxData) ->
   lists:flatten(CompiledTemplate(Ctx1)).
 
 pre_compile(T, State) ->
-  SectionRE = "{{(#|\\^)([^}]*)}}\\s*(.+?){{/\\2}}\\s*",
-  {ok, CompiledSectionRE} = re:compile(SectionRE, [dotall]),
-  TagRE = "{{(#|=|!|<|>|{|&)?(.+?)\\1?}}+",
-  {ok, CompiledTagRE} = re:compile(TagRE, [dotall]),
-  State2 = State#mstate{section_re = CompiledSectionRE, tag_re = CompiledTagRE},
+  {Left, Right} = {"{{", "}}"},
+  State2 = set_delimiters(Left, Right, State),
   "fun(Ctx) -> " ++
     compiler(T, State2) ++ " end.".
 
@@ -119,15 +117,17 @@ compiler(T, State) ->
 compile_section("#", Name, Content, State) ->
   Mod = State#mstate.mod,
   Key = compile_dot_notation(Name),
-  Result = compiler(Content, State),
+  Result = compiler(Content, add_section_path(Key, State)),
   "fun() -> " ++
     "case " ++ ?MUSTACHE_STR ++ ":get(" ++ Key ++ ", Ctx, " ++ atom_to_list(Mod) ++ ") of " ++
       "\"true\" -> " ++ Result ++ "; " ++
       "\"false\" -> []; " ++
       "List when is_list(List) -> " ++
         "[fun(Ctx) -> " ++ Result ++ " end(" ++ ?MUSTACHE_CTX_STR ++ ":merge(SubCtx, Ctx)) || SubCtx <- List]; " ++
+      "Fun when is_function(Fun, 1) -> " ++
+        "Fun(" ++ Result ++ ");"
       "Else -> " ++
-        "throw({template, io_lib:format(\"Bad context for ~p: ~p\", [" ++ Name ++ ", Else])}) " ++
+        "throw({template, io_lib:format(\"Bad context for ~p: ~p\", [\"" ++ Name ++ "\", Else])}) " ++
     "end " ++
   "end()";
 compile_section("^", Name, Content, State) ->
@@ -142,18 +142,18 @@ compile_section("^", Name, Content, State) ->
     "end " ++
   "end()".
 
-compile_tags(T, State) ->
-  Res = re:run(T, State#mstate.tag_re),
+compile_tags(T, State0) ->
+  Res = re:run(T, State0#mstate.tag_re),
   case Res of
     {match, [{M0, M1}, K, {C0, C1}]} ->
       Front = string:substr(T, 1, M0),
       Back = string:substr(T, M0 + M1 + 1),
       Content = string:substr(T, C0 + 1, C1),
       Kind = tag_kind(T, K),
-      Result = compile_tag(Kind, Content, State),
+      {Result, State1} = compile_tag(Kind, Content, State0),
       "[\"" ++ escape_special(Front) ++
         "\" | [" ++ Result ++
-        " | " ++ compile_tags(Back, State) ++ "]]";
+        " | " ++ compile_tags(Back, State1) ++ "]]";
     nomatch ->
       "[\"" ++ escape_special(T) ++ "\"]"
   end.
@@ -164,13 +164,16 @@ tag_kind(T, {K0, K1}) ->
   string:substr(T, K0 + 1, K1).
 
 compile_tag(none, Content, State) ->
-  compile_escaped_tag(Content, State);
+  {compile_escaped_tag(Content, State), State};
 compile_tag("&", Content, State) ->
-  compile_unescaped_tag(Content, State);
+  {compile_unescaped_tag(Content, State), State};
 compile_tag("{", Content, State) ->
-  compile_unescaped_tag(Content, State);
-compile_tag("!", _Content, _State) ->
-  "[]".
+  {compile_unescaped_tag(Content, State), State};
+compile_tag("!", _Content, State) ->
+  {"[]", State};
+compile_tag("=", Content, State) ->
+  [Left, Right] = string:tokens(Content, " "),
+  {"[]", set_delimiters(Left, Right, State)}.
 
 compile_escaped_tag(Content, State) ->
   Mod = State#mstate.mod,
@@ -248,6 +251,28 @@ escape_char($')  -> "\\'";
 escape_char($")  -> "\\\"";
 escape_char($\\) -> "\\\\";
 escape_char(Char) -> Char.
+
+set_delimiters(Left, Right, State) ->
+  {ok, CompiledSectionRE} = section_re(Left, Right),
+  {ok, CompiledTagRE} = tag_re(Left, Right),
+  State#mstate{section_re = CompiledSectionRE, tag_re = CompiledTagRE}.
+
+section_re(Left0, Right0) ->
+    {Left1, Right1} = {escape_delimiter(Left0), escape_delimiter(Right0)},
+    Stop = ["([^", hd(Right0), "]*)"],
+    Regexp = [Left1, "(#|\\^)", Stop, Right1, "\\s*(.+?)", Left1, "/\\2", Right1, "\\s*"],
+    re:compile(Regexp, [dotall]).
+
+tag_re(Left0, Right0) ->
+    {Left1, Right1} = {escape_delimiter(Left0), escape_delimiter(Right0)},
+    Regexp = [Left1, "(#|=|!|<|>|{|&)?(.+?)\\1?", Right1, "+"],
+    re:compile(Regexp, [dotall]).
+
+escape_delimiter(Delimiter) ->
+    lists:map(fun (Char) -> [$\\, Char] end, Delimiter).
+
+add_section_path(Key, #mstate{path = Path} = State) ->
+    State#mstate{path = Path ++ Key}.
 
 %%---------------------------------------------------------------------------
 

--- a/src/mustache_ctx.erl
+++ b/src/mustache_ctx.erl
@@ -26,6 +26,7 @@
 -module(mustache_ctx).
 
 -define(MODULE_KEY, '__mod__').
+-define(THIS_KEY, '__this__').
 -define(NEW_EXIT(Data), exit({improper_ctx, Data})).
 
 -export([ new/0, new/1, to_list/1 ]).
@@ -70,9 +71,10 @@ to_list(Ctx) ->
 %% Merge
 %% ===================================================================
 
-merge(Ctx1, Ctx2) ->
-    maps:merge(Ctx2, Ctx1).
-
+merge(Ctx1, Ctx2) when is_map(Ctx1), is_map(Ctx2) ->
+    maps:merge(Ctx2, Ctx1);
+merge(This, Ctx) when is_map(Ctx) ->
+    maps:put(?THIS_KEY, This, Ctx).
 
 %% ===================================================================
 %% Dynamic data module
@@ -91,6 +93,8 @@ module(Module, Ctx) ->
 %% Module
 %% ===================================================================
 
+get([], Ctx) ->
+    {ok, maps:get(?THIS_KEY, Ctx)};
 get(Path, Ctx) when is_list(Path) ->
     case get_path(Path, Ctx) of
         {ok, Value} -> {ok, Value};

--- a/test/mustache_ctx_tests.erl
+++ b/test/mustache_ctx_tests.erl
@@ -1,5 +1,4 @@
 -module(mustache_ctx_tests).
--compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -16,7 +15,7 @@ new_ctx_from_proplist_test() ->
 
 new_ctx_from_dict_test() ->
     List = [{k,v}],
-    Dict = dict:from_list(List),
+    Dict = maps:from_list(List),
     CtxFromList = mustache_ctx:new(List),
     CtxFromDict = mustache_ctx:new(Dict),
     ?assertEqual(CtxFromList, CtxFromDict).
@@ -62,7 +61,7 @@ get_from_module_not_found_test() ->
 
 get_from_module_test_() ->
     {foreach,
-        fun() -> ok = meck:new(mock_module) end,
+        fun() -> ok = meck:new(mock_module, [non_strict]) end,
         fun(_) -> ok = meck:unload(mock_module) end,
         [
             {"fun/1",               fun get_from_module_fun_1_/0},

--- a/test/mustache_ctx_tests.erl
+++ b/test/mustache_ctx_tests.erl
@@ -44,20 +44,20 @@ ctx_to_list_with_module_test() ->
 
 get_from_empty_test() ->
     Ctx = mustache_ctx:new(),
-    ?assertEqual({error, not_found}, mustache_ctx:get(key, Ctx)).
+    ?assertEqual({error, not_found}, mustache_ctx:get([key], Ctx)).
 
 get_not_found_test() ->
     Ctx = mustache_ctx:new([{k,v}]),
-    ?assertEqual({error, not_found}, mustache_ctx:get(key, Ctx)).
+    ?assertEqual({error, not_found}, mustache_ctx:get([key], Ctx)).
 
 get_found_test() ->
     Ctx = mustache_ctx:new([{key,value}]),
-    ?assertEqual({ok, value}, mustache_ctx:get(key, Ctx)).
+    ?assertEqual({ok, value}, mustache_ctx:get([key], Ctx)).
 
 get_from_module_not_found_test() ->
     Ctx0 = mustache_ctx:new(),
     Ctx1 = mustache_ctx:module(mock_module, Ctx0),
-    ?assertEqual({error, not_found}, mustache_ctx:get(key, Ctx1)).
+    ?assertEqual({error, not_found}, mustache_ctx:get([key], Ctx1)).
 
 get_from_module_test_() ->
     {foreach,
@@ -73,33 +73,33 @@ get_from_module_fun_1_() ->
     ok = meck:expect(mock_module, key, fun(_) -> value end),
     Ctx0 = mustache_ctx:new(),
     Ctx1 = mustache_ctx:module(mock_module, Ctx0),
-    ?assertEqual({ok, value}, mustache_ctx:get(key, Ctx1)).
+    ?assertEqual({ok, value}, mustache_ctx:get([key], Ctx1)).
 
 get_from_module_fun_0_() ->
     ok = meck:expect(mock_module, key, fun() -> value end),
     Ctx0 = mustache_ctx:new(),
     Ctx1 = mustache_ctx:module(mock_module, Ctx0),
-    ?assertEqual({ok, value}, mustache_ctx:get(key, Ctx1)).
+    ?assertEqual({ok, value}, mustache_ctx:get([key], Ctx1)).
 
 get_from_module_call_order_() ->
     ok = meck:expect(mock_module, key, fun(_) -> value_1 end),
     ok = meck:expect(mock_module, key, fun() -> value_0 end),
     Ctx0 = mustache_ctx:new(),
     Ctx1 = mustache_ctx:module(mock_module, Ctx0),
-    ?assertEqual({ok, value_1}, mustache_ctx:get(key, Ctx1)).
+    ?assertEqual({ok, value_1}, mustache_ctx:get([key], Ctx1)).
 
 merge_disjoin_test() ->
     Ctx1 = mustache_ctx:new([{k1,v1}]),
     Ctx2 = mustache_ctx:new([{k2,v2}]),
     Ctx = mustache_ctx:merge(Ctx1, Ctx2),
-    ?assertEqual({ok, v1}, mustache_ctx:get(k1, Ctx)),
-    ?assertEqual({ok, v2}, mustache_ctx:get(k2, Ctx)).
+    ?assertEqual({ok, v1}, mustache_ctx:get([k1], Ctx)),
+    ?assertEqual({ok, v2}, mustache_ctx:get([k2], Ctx)).
 
 merge_intersecting_test() ->
     Ctx1 = mustache_ctx:new([{k0, v1}, {k1,v1}]),
     Ctx2 = mustache_ctx:new([{k0, v2}, {k2,v2}]),
     Ctx = mustache_ctx:merge(Ctx1, Ctx2),
-    ?assertEqual({ok, v1}, mustache_ctx:get(k0, Ctx)),
-    ?assertEqual({ok, v1}, mustache_ctx:get(k1, Ctx)),
-    ?assertEqual({ok, v2}, mustache_ctx:get(k2, Ctx)).
+    ?assertEqual({ok, v1}, mustache_ctx:get([k0], Ctx)),
+    ?assertEqual({ok, v1}, mustache_ctx:get([k1], Ctx)),
+    ?assertEqual({ok, v2}, mustache_ctx:get([k2], Ctx)).
 

--- a/test/mustache_tests.erl
+++ b/test/mustache_tests.erl
@@ -52,10 +52,26 @@ simple_dot_test() ->
     Result = mustache:render(<<"Hello {{name.first}} {{name.last}}!">>, Ctx),
     ?assertEqual(<<"Hello Emil Falk!">>, Result).
 
-section_dot_test() ->
+simple_section_dot_test() ->
     Ctx = #{test => lists:seq(1,3)},
     Result = mustache:render(<<"{{#test}}{{.}}{{/test}}">>, Ctx),
     ?assertEqual(<<"123">>, Result).
+
+complex_section_dot_test() ->
+    Ctx = #{test1 => #{test2 => lists:seq(1, 3)}},
+    Result = mustache:render(<<"{{#test1.test2}}{{.}}{{/test1.test2}}">>, Ctx),
+    ?assertEqual(<<"123">>, Result).
+
+fun_test() ->
+    Ctx = #{test1 => fun (Text) -> re:replace(Text, "xxx", "yyy") end,
+            test2 => "xxx"},
+    Result = mustache:render(<<"{{#test1}}{{test2}}{{/test1}}">>, Ctx),
+    ?assertEqual(<<"yyy">>, Result).
+
+set_delimiter_test() ->
+    Ctx = #{test1 => <<"TEST1">>, test2 => <<"TEST2">>},
+    Result = mustache:render(<<"{{=[[ ]]=}}[[test1]] [[={{ }}=]]{{test2}}">>, Ctx),
+    ?assertEqual(<<"TEST1 TEST2">>, Result).
 
 %% ===================================================================
 %% basic tag types

--- a/test/mustache_tests.erl
+++ b/test/mustache_tests.erl
@@ -25,22 +25,20 @@
 
 -module(mustache_tests).
 
--compile(export_all).
-
 -include_lib("eunit/include/eunit.hrl").
 
 simple_test() ->
-    Ctx = dict:from_list([{name, "world"}]),
+    Ctx = maps:from_list([{name, "world"}]),
     Result = mustache:render("Hello {{name}}!", Ctx),
     ?assertEqual("Hello world!", Result).
 
 integer_values_too_test() ->
-    Ctx = dict:from_list([{name, "Chris"}, {value, 10000}]),
+    Ctx = maps:from_list([{name, "Chris"}, {value, 10000}]),
     Result = mustache:render("Hello {{name}}~nYou have just won ${{value}}!", Ctx),
     ?assertEqual("Hello Chris~nYou have just won $10000!", Result).
 
 specials_test() ->
-    Ctx = dict:from_list([{name, "Chris"}, {value, 10000}]),
+    Ctx = maps:from_list([{name, "Chris"}, {value, 10000}]),
     Result = mustache:render("\'Hello\n\"{{name}}\"~nYou \"have\" ju\0st\\ won\b\r\"${{value}}!\"\t", Ctx),
     ?assertEqual("\'Hello\n\"Chris\"~nYou \"have\" ju\0st\\ won\b\r\"$10000!\"\t", Result).
 
@@ -83,7 +81,7 @@ tag_type_section_empty_list_test() ->
     test_helper("{{#name}}section{{/name}}", "", [{name, []}]).
 
 tag_type_section_nonempty_list_test() ->
-    CtxList = [{name, [ dict:new() || _ <- lists:seq(1,3) ]}],
+    CtxList = [{name, [ #{} || _ <- lists:seq(1,3) ]}],
     test_helper("{{#name}}section{{/name}}", "sectionsectionsection", CtxList).
 
 
@@ -100,7 +98,7 @@ tag_type_inverted_section_empty_list_test() ->
     test_helper("{{^name}}section{{/name}}", "section", [{name, []}]).
 
 tag_type_inverted_section_nonempty_list_test() ->
-    CtxList = [{name, [ dict:new() || _ <- lists:seq(1,3) ]}],
+    CtxList = [{name, [ #{} || _ <- lists:seq(1,3) ]}],
     test_helper("{{^name}}section{{/name}}", "", CtxList).
 
 
@@ -115,6 +113,6 @@ tag_type_comment_multiline_test() ->
 
 
 test_helper(Template, Expected, CtxList) ->
-    Ctx = dict:from_list(CtxList),
+    Ctx = maps:from_list(CtxList),
     ?assertEqual(Expected, mustache:render(Template, Ctx)).
 

--- a/test/mustache_tests.erl
+++ b/test/mustache_tests.erl
@@ -42,6 +42,21 @@ specials_test() ->
     Result = mustache:render("\'Hello\n\"{{name}}\"~nYou \"have\" ju\0st\\ won\b\r\"${{value}}!\"\t", Ctx),
     ?assertEqual("\'Hello\n\"Chris\"~nYou \"have\" ju\0st\\ won\b\r\"$10000!\"\t", Result).
 
+binary_test() ->
+    Ctx = #{name => <<"Chris">>, value => 10000},
+    Result = mustache:render(<<"Hello {{name}}~nYou have just won ${{value}}!">>, Ctx),
+    ?assertEqual(<<"Hello Chris~nYou have just won $10000!">>, Result).
+
+simple_dot_test() ->
+    Ctx = #{name => #{first => <<"Emil">>, last => <<"Falk">>}},
+    Result = mustache:render(<<"Hello {{name.first}} {{name.last}}!">>, Ctx),
+    ?assertEqual(<<"Hello Emil Falk!">>, Result).
+
+section_dot_test() ->
+    Ctx = #{test => lists:seq(1,3)},
+    Result = mustache:render(<<"{{#test}}{{.}}{{/test}}">>, Ctx),
+    ?assertEqual(<<"123">>, Result).
+
 %% ===================================================================
 %% basic tag types
 %% ===================================================================


### PR DESCRIPTION
Tried to tidy up the README abit to reflect upon the changes made.

Erlang specific:
- Context is now a map (old dict still supported but will be converted to a map)
- Possibility to use binaries
- Fix failing tests due to regression with meck

Mustache:
- Dot-notation for nested maps
- Dot-notation for this element in list sections ({{.}})
- Simple lambda functions
- Ability to change the set delimiters
